### PR TITLE
fix mmcv version

### DIFF
--- a/waifu_squarelizer_shared.ipynb
+++ b/waifu_squarelizer_shared.ipynb
@@ -46,7 +46,7 @@
       "source": [
         "# installation\n",
         "!pip install openmim\n",
-        "!mim install mmcv-full\n",
+        "!mim install mmcv-full==1.7.0\n",
         "!mim install mmdet\n",
         "!mim install mmpose\n",
         "\n",


### PR DESCRIPTION
I tried to run your script and I got an error when the version of mmcv was too new.

I have confirmed that it works with mmcv version 1.7.0.

```
/home/thr3a/.pyenv/versions/3.10.7/lib/python3.10/site-packages/mmcv/__init__.py:20: UserWarning: On January 1, 2023, MMCV will release v2.0.0, in which it will remove components related to the training process and add a data transformation module. In addition, it will rename the package names mmcv to mmcv-lite and mmcv-full to mmcv. See https://github.com/open-mmlab/mmcv/blob/master/docs/en/compatibility.md for more details.
  warnings.warn(
Traceback (most recent call last):
  File "/home/thr3a/app.py", line 2, in <module>
    from anime_face_detector import create_detector
  File "/home/thr3a/.pyenv/versions/3.10.7/lib/python3.10/site-packages/anime_face_detector/__init__.py", line 5, in <module>
    from .detector import LandmarkDetector
  File "/home/thr3a/.pyenv/versions/3.10.7/lib/python3.10/site-packages/anime_face_detector/detector.py", line 12, in <module>
    from mmpose.apis import inference_top_down_pose_model, init_pose_model
  File "/home/thr3a/.pyenv/versions/3.10.7/lib/python3.10/site-packages/mmpose/__init__.py", line 24, in <module>
    assert (mmcv_version >= digit_version(mmcv_minimum_version)
AssertionError: MMCV==1.7.1 is used but incompatible. Please install mmcv>=1.3.8, <=1.7.0.
```